### PR TITLE
Fixed metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 RSS feed reader Model Context Protocol server.
 
-<!--
 ---
 title: RSS MCP Server
 sdk: gradio
@@ -12,4 +11,3 @@ pinned: true
 tags:
 - mcp-server-track
 ---
--->


### PR DESCRIPTION
Looks like we can't hide it from view on GitHub easily, moving on.